### PR TITLE
Should Fix #117

### DIFF
--- a/tksheet/_tksheet_main_table.py
+++ b/tksheet/_tksheet_main_table.py
@@ -2063,7 +2063,7 @@ class MainTable(tk.Canvas):
         if not bindings:
             self.enable_bindings_internal("all")
         elif isinstance(bindings, (list, tuple)):
-            for binding in bindings:
+            for binding in bindings[0]:
                 self.enable_bindings_internal(binding.lower())
         elif isinstance(bindings, str):
             self.enable_bindings_internal(bindings.lower())
@@ -2181,7 +2181,7 @@ class MainTable(tk.Canvas):
         if not bindings:
             self.disable_bindings_internal("all")
         elif isinstance(bindings, (list, tuple)):
-            for binding in bindings:
+            for binding in bindings[0]:
                 self.disable_bindings_internal(binding)
         elif isinstance(bindings, str):
             self.disable_bindings_internal(bindings)


### PR DESCRIPTION
The issue was that when you use `*bindings` as a argument in the method signature, if a tuple is passed to it 
eg. `enable_bindings(("toggle_select", "drag_select"))`
The value of `bindings` is `(("toggle_select", "drag_select"), )`, a tuple of all the values inside a tuple.
Therefore `lower()` crashes.

Same goes for `disable_bindings()`