### PR TITLE
Should Fix #117

### DIFF
--- a/tksheet/_tksheet_main_table.py
+++ b/tksheet/_tksheet_main_table.py
@@ -2063,7 +2063,7 @@ class MainTable(tk.Canvas):
         if not bindings:
             self.enable_bindings_internal("all")
         elif isinstance(bindings, (list, tuple)):
-            for binding in bindings:
+            for binding in bindings[0]:
                 self.enable_bindings_internal(binding.lower())
         elif isinstance(bindings, str):
             self.enable_bindings_internal(bindings.lower())
@@ -2181,7 +2181,7 @@ class MainTable(tk.Canvas):
         if not bindings:
             self.disable_bindings_internal("all")
         elif isinstance(bindings, (list, tuple)):
-            for binding in bindings:
+            for binding in bindings[0]:
                 self.disable_bindings_internal(binding)
         elif isinstance(bindings, str):
             self.disable_bindings_internal(bindings)

--- a/tksheet/_tksheet_main_table.py
+++ b/tksheet/_tksheet_main_table.py
@@ -2063,8 +2063,12 @@ class MainTable(tk.Canvas):
         if not bindings:
             self.enable_bindings_internal("all")
         elif isinstance(bindings, (list, tuple)):
-            for binding in bindings[0]:
-                self.enable_bindings_internal(binding.lower())
+            for binding in bindings:
+                if isinstance(binding, (list, tuple)):
+                    for bind in binding:
+                        self.enable_bindings_internal(bind.lower())
+                else:
+                    self.enable_bindings_internal(binding.lower())
         elif isinstance(bindings, str):
             self.enable_bindings_internal(bindings.lower())
 
@@ -2181,8 +2185,12 @@ class MainTable(tk.Canvas):
         if not bindings:
             self.disable_bindings_internal("all")
         elif isinstance(bindings, (list, tuple)):
-            for binding in bindings[0]:
-                self.disable_bindings_internal(binding)
+            for binding in bindings:
+                if isinstance(binding, (list, tuple)):
+                    for bind in binding:
+                        self.enable_bindings_internal(bind.lower())
+                else:
+                    self.enable_bindings_internal(binding.lower())
         elif isinstance(bindings, str):
             self.disable_bindings_internal(bindings)
 


### PR DESCRIPTION
The issue was that when you use `*bindings` as a argument in the method signature, if a tuple is passed to it
eg. `enable_bindings(("toggle_select", "drag_select"))`
The value of bindings is `(("toggle_select", "drag_select"), )`, a tuple of all the values inside a tuple.
Therefore `lower()` crashes.

Same goes for `disable_bindings()`

This fix for #117  seems to be working fine:

![image](https://user-images.githubusercontent.com/30069380/163196813-cadd409d-75db-4c16-9c12-9c53d6dd35a8.png)
