### PR TITLE
Undo Bugfix

### DIFF
--- a/tksheet/_tksheet_main_table.py
+++ b/tksheet/_tksheet_main_table.py
@@ -5346,7 +5346,7 @@ class MainTable(tk.Canvas):
         if datarn is None:
             datarn = r if self.all_rows_displayed else self.displayed_rows[r]
         if self.undo_enabled and undo:
-            if self.data[r][datacn] != value:
+            if (f"{self.data[r][datacn]}" if self.data[r][datacn] is not None else "") != value:
                 self.undo_storage.append(zlib.compress(pickle.dumps(("edit_cells",
                                                                      {(datarn, datacn): self.get_cell_data(datarn, datacn)},
                                                                      (((r, c, r + 1, c + 1), "cells"), ),


### PR DESCRIPTION
Very minor bugfix, just noticed that null and formatted cells would be added to the undo stack due when they were opened and closed without any changes being made. This is due to `set_cell_data_undo` comparing the converted datatype with the string output from the `TextEditor`. It now compares the string format of the datatype, with `NoneType` converted to `""`. 

Otherwise, I have found no further bugs in my testing. Thanks for all your cooperation, this update will make tksheet an extremely useful interface for database CRUD operations and certainly will have other applications too. Hopefully it'll soon replace our extremely janky excel-based solution that is in a constant state of brokenness. 

Going forward, I have a few more features I am working on that I might want to merge down the line. At the moment I have been working on extending the functionality of the dropdown cells to include an optional search-box to make sorting through large lists of options a bit easier. If this sounds like a good idea, I'll open up an issue thread so we can discuss the details a bit further. 

Thanks again,
C
