### PR TITLE
Added UI edit events, bugfixes

### DIFF
--- a/tksheet/_tksheet_column_headers.py
+++ b/tksheet/_tksheet_column_headers.py
@@ -1226,7 +1226,7 @@ class ColumnHeaders(tk.Canvas):
         text = "" if text is None else text
         if self.MT.cell_auto_resize_enabled:
             if self.height_resizing_enabled:
-                self.set_current_height_to_text(text)
+                self.set_current_height_to_text(text, datacn)
             self.set_col_width_run_binding(c)
         self.select_col(c = c, keep_other_selections = True)
         self.create_text_editor(c = c, text = text, set_data_on_close = True, dropdown = dropdown)
@@ -1437,7 +1437,7 @@ class ColumnHeaders(tk.Canvas):
                 self.set_cell_data(datacn = datacn, value = value)
         if cell_resize and self.MT.cell_auto_resize_enabled:
             if self.height_resizing_enabled:
-                self.set_current_height_to_text(value)
+                self.set_current_height_to_text(value, datacn)
             self.set_col_width_run_binding(c)
         if redraw:
             self.MT.refresh()
@@ -1614,10 +1614,10 @@ class ColumnHeaders(tk.Canvas):
             win_h = win_h2
         return win_h, "nw"
 
-    def set_current_height_to_text(self, text):
+    def set_current_height_to_text(self, text, datacn):
         x = self.MT.txt_measure_canvas.create_text(0,
                                                    0,
-                                                   text = self.MT.get_valid_cell_data_as_str(text) if isinstance(self.MT._headers, int) else text,
+                                                   text = self.MT.get_valid_cell_data_as_str(self.MT._headers, datacn, get_displayed = True) if isinstance(self.MT._headers, int) else text,
                                                    font = self.MT._hdr_font)
         b = self.MT.txt_measure_canvas.bbox(x)
         self.MT.txt_measure_canvas.delete(x)

--- a/tksheet/_tksheet_column_headers.py
+++ b/tksheet/_tksheet_column_headers.py
@@ -556,6 +556,7 @@ class ColumnHeaders(tk.Canvas):
                     self.MT.main_table_redraw_grid_and_text(redraw_header = True, redraw_row_index = True)
                     if self.ch_extra_end_drag_drop_func is not None:
                         self.ch_extra_end_drag_drop_func(EndDragDropEvent("end_column_header_drag_drop", tuple(orig_selected), new_selected, int(c)))
+                    self.event_generate("<<SheetDataChangeEvent>>")
         elif self.b1_pressed_loc is not None and self.rsz_w is None and self.rsz_h is None:
             c = self.MT.identify_col(x = event.x)
             if c is not None and c < len(self.MT.col_positions) - 1 and c == self.b1_pressed_loc and self.b1_pressed_loc != self.closed_dropdown:
@@ -1225,7 +1226,7 @@ class ColumnHeaders(tk.Canvas):
         text = "" if text is None else text
         if self.MT.cell_auto_resize_enabled:
             if self.height_resizing_enabled:
-                self.set_current_height_to_cell(datacn)
+                self.set_current_height_to_text(text)
             self.set_col_width_run_binding(c)
         self.select_col(c = c, keep_other_selections = True)
         self.create_text_editor(c = c, text = text, set_data_on_close = True, dropdown = dropdown)
@@ -1436,10 +1437,11 @@ class ColumnHeaders(tk.Canvas):
                 self.set_cell_data(datacn = datacn, value = value)
         if cell_resize and self.MT.cell_auto_resize_enabled:
             if self.height_resizing_enabled:
-                self.set_current_height_to_cell(datacn)
+                self.set_current_height_to_text(value)
             self.set_col_width_run_binding(c)
         if redraw:
             self.MT.refresh()
+        self.event_generate("<<SheetDataChangeEvent>>")
     
     def set_cell_data(self, datacn = None, value = ""):
         if isinstance(self.MT._headers, int):
@@ -1612,10 +1614,10 @@ class ColumnHeaders(tk.Canvas):
             win_h = win_h2
         return win_h, "nw"
 
-    def set_current_height_to_cell(self, datacn):
+    def set_current_height_to_text(self, text):
         x = self.MT.txt_measure_canvas.create_text(0,
                                                    0,
-                                                   text = self.MT.get_valid_cell_data_as_str(self.MT._headers, datacn, get_displayed = True) if isinstance(self.MT._headers, int) else self.MT._headers[datacn],
+                                                   text = self.MT.get_valid_cell_data_as_str(text) if isinstance(self.MT._headers, int) else text,
                                                    font = self.MT._hdr_font)
         b = self.MT.txt_measure_canvas.bbox(x)
         self.MT.txt_measure_canvas.delete(x)

--- a/tksheet/_tksheet_main_table.py
+++ b/tksheet/_tksheet_main_table.py
@@ -508,6 +508,7 @@ class MainTable(tk.Canvas):
             self.show_ctrl_outline(canvas = "table", start_cell = (c1, r1), end_cell = (c2, r2))
         if self.extra_end_ctrl_x_func is not None:
             self.extra_end_ctrl_x_func(CtrlKeyEvent("end_ctrl_x", boxes, currently_selected, rows))
+        self.event_generate("<<SheetDataChangeEvent>>")
 
     def find_last_selected_box_with_current(self, currently_selected):
         if currently_selected.type_ in ("cell", "column"):
@@ -636,6 +637,7 @@ class MainTable(tk.Canvas):
         self.refresh()
         if self.extra_end_ctrl_v_func is not None:
             self.extra_end_ctrl_v_func(PasteEvent("end_ctrl_v", currently_selected, rows))
+        self.event_generate("<<SheetDataChangeEvent>>")
 
     def delete_key(self, event = None):
         if self.anything_selected():
@@ -672,6 +674,7 @@ class MainTable(tk.Canvas):
             if changes and self.undo_enabled:
                 self.undo_storage.append(zlib.compress(pickle.dumps(("edit_cells", undo_storage, tuple(boxes.items()), currently_selected))))
             self.refresh()
+            self.event_generate("<<SheetDataChangeEvent>>")
             
     def move_columns_adjust_options_dict(self, col, to_move_min, num_cols, move_data = True, create_selections = True):
         c = int(col)
@@ -1128,6 +1131,7 @@ class MainTable(tk.Canvas):
         self.refresh()
         if self.extra_end_ctrl_z_func is not None:
             self.extra_end_ctrl_z_func(UndoEvent("end_ctrl_z", undo_storage[0], undo_storage))
+        self.event_generate("<<SheetDataChangeEvent>>")
 
     def bind_arrowkeys(self, keys: dict = {}):
         for canvas in (self, self.parentframe, self.CH, self.RI, self.TL):
@@ -3353,6 +3357,7 @@ class MainTable(tk.Canvas):
         self.refresh()
         if self.extra_end_insert_cols_rc_func is not None:
             self.extra_end_insert_cols_rc_func(InsertEvent("end_insert_columns", data_ins_col, displayed_ins_col, numcols))
+        self.event_generate("<<SheetDataChangeEvent>>")
 
     def insert_row_rc(self, event = None):
         if self.anything_selected(exclude_columns = True, exclude_cells = True):
@@ -3402,6 +3407,7 @@ class MainTable(tk.Canvas):
         self.refresh()
         if self.extra_end_insert_rows_rc_func is not None:
             self.extra_end_insert_rows_rc_func(InsertEvent("end_insert_rows", stidx, posidx, numrows))
+        self.event_generate("<<SheetDataChangeEvent>>")
             
     def del_cols_rc(self, event = None):
         seld_cols = sorted(self.get_selected_cols())
@@ -3470,6 +3476,7 @@ class MainTable(tk.Canvas):
             self.refresh()
             if self.extra_end_del_cols_rc_func is not None:
                 self.extra_end_del_cols_rc_func(DeleteRowColumnEvent("end_delete_columns", seld_cols))
+            self.event_generate('<<SheetDataChangeEvent>>')
 
     def del_rows_rc(self, event = None):
         seld_rows = sorted(self.get_selected_rows())
@@ -3527,6 +3534,7 @@ class MainTable(tk.Canvas):
             self.refresh()
             if self.extra_end_del_rows_rc_func is not None:
                 self.extra_end_del_rows_rc_func(DeleteRowColumnEvent("end_delete_rows", seld_rows))
+            self.event_generate('<<SheetDataChangeEvent>>')
 
     def move_row_position(self, idx1, idx2):
         if not len(self.row_positions) <= 2:
@@ -5324,7 +5332,7 @@ class MainTable(tk.Canvas):
             self.set_cell_data(datarn, datacn, value)
         if cell_resize and self.cell_auto_resize_enabled:
             self.set_cell_size_to_text(r, c, only_set_if_too_small = True, redraw = redraw, run_binding = True)
-        self.generate_event('<<SheetDataChangeEvent>>')
+        self.event_generate('<<SheetDataChangeEvent>>')
         return True
     
     def set_cell_data(self, datarn, datacn, value, kwargs = {}, expand_sheet = True):
@@ -5419,6 +5427,7 @@ class MainTable(tk.Canvas):
             self.cell_options[(datarn, datacn)] = {}
         self.cell_options[(datarn, datacn)]['format'] = kwargs
         self.set_cell_data(datarn, datacn, value = v, kwargs = kwargs)
+        self.event_generate('<<SheetDataChangeEvent>>')
         
     def format_row(self, datarn, **kwargs):
         kwargs = self.format_fix_kwargs(kwargs)
@@ -5430,6 +5439,7 @@ class MainTable(tk.Canvas):
                                datacn,
                                value = kwargs['value'] if 'value' in kwargs else self.get_cell_data(datarn, datacn),
                                kwargs = kwargs)
+        self.event_generate('<<SheetDataChangeEvent>>')
             
     def format_column(self, datacn, **kwargs):
         kwargs = self.format_fix_kwargs(kwargs)
@@ -5441,6 +5451,7 @@ class MainTable(tk.Canvas):
                                datacn,
                                value = kwargs['value'] if 'value' in kwargs else self.get_cell_data(datarn, datacn),
                                kwargs = kwargs)
+        self.event_generate('<<SheetDataChangeEvent>>')
             
     def format_sheet(self, **kwargs):
         kwargs = self.format_fix_kwargs(kwargs)
@@ -5451,6 +5462,7 @@ class MainTable(tk.Canvas):
                                    datacn,
                                    value = kwargs['value'] if 'value' in kwargs else self.get_cell_data(datarn, datacn),
                                    kwargs = kwargs)
+        self.event_generate('<<SheetDataChangeEvent>>')
 
     def format_fix_kwargs(self, kwargs):
         if kwargs['formatter'] is None:

--- a/tksheet/_tksheet_main_table.py
+++ b/tksheet/_tksheet_main_table.py
@@ -3479,7 +3479,7 @@ class MainTable(tk.Canvas):
                     self.extra_begin_del_rows_rc_func(DeleteRowColumnEvent("begin_delete_rows", seld_rows))
                 except:
                     return
-            seldset = set(seld_rows) if self.all_rows_displayed else set(self.displayed_rows[c] for r in seld_rows)
+            seldset = set(seld_rows) if self.all_rows_displayed else set(self.displayed_rows[r] for r in seld_rows)
             list_of_coords = tuple((r, c) for (r, c) in self.cell_options if r in seldset)
             if self.undo_enabled:
                 undo_storage = {'deleted_rows': [],
@@ -5324,6 +5324,7 @@ class MainTable(tk.Canvas):
             self.set_cell_data(datarn, datacn, value)
         if cell_resize and self.cell_auto_resize_enabled:
             self.set_cell_size_to_text(r, c, only_set_if_too_small = True, redraw = redraw, run_binding = True)
+        self.generate_event('<<SheetDataChangeEvent>>')
         return True
     
     def set_cell_data(self, datarn, datacn, value, kwargs = {}, expand_sheet = True):

--- a/tksheet/_tksheet_row_index.py
+++ b/tksheet/_tksheet_row_index.py
@@ -544,6 +544,7 @@ class RowIndex(tk.Canvas):
                     self.MT.main_table_redraw_grid_and_text(redraw_header = True, redraw_row_index = True)
                     if self.ri_extra_end_drag_drop_func is not None:
                         self.ri_extra_end_drag_drop_func(EndDragDropEvent("end_row_index_drag_drop", tuple(orig_selected), new_selected, int(r)))
+                    self.event_generate("<<SheetDataChangeEvent>>")
                         
         elif self.b1_pressed_loc is not None and self.rsz_w is None and self.rsz_h is None:
             r = self.MT.identify_row(y = event.y)
@@ -1471,6 +1472,7 @@ class RowIndex(tk.Canvas):
             self.set_row_height_run_binding(r, only_set_if_too_small = False)
         if redraw:
             self.MT.refresh()
+        self.event_generate('<<SheetDataChangeEvent>>')
 
     def set_cell_data(self, datarn = None, value = ""):
         if isinstance(self.MT._row_index, int):


### PR DESCRIPTION
Hello!
I have added events for external listeners so that programs know when changes are being made to the sheet via the UI. This can be useful in cases where parts of the sheet or program need to be updated dynamically based on what is on the sheet without comparing the sheet data every mainloop iteration. Each edit to the table should produce one event that occurs after tksheet has made all the internal changes to its data. 

Note that edits to the sheet data through code should produce no event, this is because the code should know if it is making changes and it is easy to create infinite loops of editing events if the code changes to sheet data produce events which spawn more changes.

This is somewhat a response to issue #170. I think this is a better way for users to handle calculated cells going forward as the actual logic sits outside the widget itself. 

Here is a small code example where column C is the sum of A and B:
```
from tksheet import Sheet, float_formatter
import tkinter as tk

class demo(tk.Tk):
    def __init__(self):
        tk.Tk.__init__(self)
        self.bind('<<SheetDataChangeEvent>>', self.on_data_change)
        self.i = 0
        self.grid_columnconfigure(0, weight = 1)
        self.grid_rowconfigure(0, weight = 1)
        self.frame = tk.Frame(self)
        self.frame.grid_columnconfigure(0, weight = 1)
        self.frame.grid_rowconfigure(0, weight = 1)
        self.sheet = Sheet(self.frame, total_rows=2, total_columns=2
                           )
        self.sheet.enable_bindings()
        self.frame.grid(row = 0, column = 0, sticky = "nswe")
        self.sheet.grid(row = 0, column = 0, sticky = "nswe")
        self.sheet.align_columns(0, "center")
        self.sheet.align_columns(1, "left")
        self.sheet.format_sheet(formatter_options = float_formatter(decimals = 7))
        self.sheet.set_sheet_data([[None, None, None],[1,1, None]])
        self.sheet.readonly_columns(2)
        self.perform_calcs()
        

    def on_data_change(self, event):
        self.i += 1
        self.perform_calcs()

    def perform_calcs(self):
        for r, row in enumerate(self.sheet.get_sheet_data()):
            try: 
                row[2] = row[0] + row[1]
            except:
                row[2] = None
            print(row)
            self.sheet.set_row_data(r, row)
        self.sheet.redraw()
    
app = demo()
app.mainloop()
```