### PR TITLE
Added Event Data 

### DIFF
--- a/tksheet/_tksheet.py
+++ b/tksheet/_tksheet.py
@@ -16,7 +16,7 @@ class Sheet(tk.Frame):
     def __init__(
         self,
         parent,
-        name: str = "tksheet",
+        name: str = "!sheet",
         show_table: bool = True,
         show_top_left: bool = True,
         show_row_index: bool = True,

--- a/tksheet/_tksheet.py
+++ b/tksheet/_tksheet.py
@@ -16,6 +16,7 @@ class Sheet(tk.Frame):
     def __init__(
         self,
         parent,
+        name: str = "tksheet",
         show_table: bool = True,
         show_top_left: bool = True,
         show_row_index: bool = True,
@@ -141,7 +142,9 @@ class Sheet(tk.Frame):
             highlightthickness=outline_thickness,
             highlightbackground=outline_color,
             highlightcolor=outline_color,
+            name=name,
         )
+        self.name = name
         self.C = parent
         self.dropdown_class = Sheet_Dropdown
         self.after_redraw_id = None
@@ -719,6 +722,7 @@ class Sheet(tk.Frame):
                     self.MT.deselection_binding_func = func
 
     def emit_event(self, event, data={}):
+        data['name']=self.name
         self.event_generate(event, data=data)
 
     def bind_event(self, sequence, func, add=None):

--- a/tksheet/_tksheet_column_headers.py
+++ b/tksheet/_tksheet_column_headers.py
@@ -989,9 +989,16 @@ class ColumnHeaders(tk.Canvas):
                                 int(c),
                             )
                         )
+                    moved_cols = [(start, end) for start, end in zip(orig_selected, new_selected) if start != end]
+                    modified_cols=list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1))
+                    direction = -1 if c < rm1start else 1
+                    displacement = -direction * totalcols
+                    displaced_cols = [(start, start+displacement) for start in modified_cols if start not in orig_selected]
+                    moved_cols += displaced_cols
                     event_data = sheet_modified_event_data(
                         action="move_cols",
-                        modified_cols=list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1)),
+                        modified_cols=modified_cols,
+                        moved_cols=moved_cols,
                     )
                     self.parentframe.emit_event("<<SheetModified>>", event_data)
         elif (

--- a/tksheet/_tksheet_column_headers.py
+++ b/tksheet/_tksheet_column_headers.py
@@ -989,11 +989,10 @@ class ColumnHeaders(tk.Canvas):
                                 int(c),
                             )
                         )
-                    event_data = {'action': 'move_cols', 
-                                  'modified': {'cells': [], 'rows': [], 'cols': []}, 
-                                  'deleted': {'rows': [], 'cols': []}, 
-                                  'added': {'rows': [], 'cols': []}}
-                    event_data["modified"]["cols"] = list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1))
+                    event_data = sheet_modified_event_data(
+                        action="move_cols",
+                        modified_cols=list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1)),
+                    )
                     self.parentframe.emit_event("<<SheetModified>>", event_data)
         elif (
             self.b1_pressed_loc is not None
@@ -2328,11 +2327,10 @@ class ColumnHeaders(tk.Canvas):
             self.set_col_width_run_binding(c)
         if redraw:
             self.MT.refresh()
-        event_data = {'action': 'edit_header', 
-                      'modified': {'cells': [], 'rows': [], 'cols': []}, 
-                      'deleted': {'rows': [], 'cols': []}, 
-                      'added': {'rows': [], 'cols': []}}
-        event_data['modified']['cols'].append(datacn)
+        event_data = sheet_modified_event_data(
+            action="edit_header",
+            modified_cols=[datacn],
+        )
         self.parentframe.emit_event("<<SheetModified>>", event_data)
 
     def set_cell_data(self, datacn=None, value=""):

--- a/tksheet/_tksheet_column_headers.py
+++ b/tksheet/_tksheet_column_headers.py
@@ -989,7 +989,12 @@ class ColumnHeaders(tk.Canvas):
                                 int(c),
                             )
                         )
-                    self.parentframe.emit_event("<<SheetModified>>")
+                    event_data = {'action': 'move_cols', 
+                                  'modified': {'cells': [], 'rows': [], 'cols': []}, 
+                                  'deleted': {'rows': [], 'cols': []}, 
+                                  'added': {'rows': [], 'cols': []}}
+                    event_data["modified"]["cols"] = list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1))
+                    self.parentframe.emit_event("<<SheetModified>>", event_data)
         elif (
             self.b1_pressed_loc is not None
             and self.rsz_w is None
@@ -2323,7 +2328,12 @@ class ColumnHeaders(tk.Canvas):
             self.set_col_width_run_binding(c)
         if redraw:
             self.MT.refresh()
-        self.parentframe.emit_event("<<SheetModified>>")
+        event_data = {'action': 'edit_header', 
+                      'modified': {'cells': [], 'rows': [], 'cols': []}, 
+                      'deleted': {'rows': [], 'cols': []}, 
+                      'added': {'rows': [], 'cols': []}}
+        event_data['modified']['cols'].append(datacn)
+        self.parentframe.emit_event("<<SheetModified>>", event_data)
 
     def set_cell_data(self, datacn=None, value=""):
         if isinstance(self.MT._headers, int):

--- a/tksheet/_tksheet_main_table.py
+++ b/tksheet/_tksheet_main_table.py
@@ -1518,12 +1518,14 @@ class MainTable(tk.Canvas):
                 self._headers[c] = v
             self.reselect_from_get_boxes(undo_storage[2])
             self.set_currently_selected(0, undo_storage[3][1], type_="column")
+            event_data['modified']['cols'] = list(undo_storage[1].keys())
 
         if undo_storage[0] in ("edit_index",):
             for r, v in undo_storage[1].items():
                 self._row_index[r] = v
             self.reselect_from_get_boxes(undo_storage[2])
             self.set_currently_selected(0, undo_storage[3][1], type_="row")
+            event_data['modified']['rows'] = list(undo_storage[1].keys())
 
         if undo_storage[0] in ("edit_cells", "edit_cells_paste"):
             cells = []

--- a/tksheet/_tksheet_main_table.py
+++ b/tksheet/_tksheet_main_table.py
@@ -714,7 +714,7 @@ class MainTable(tk.Canvas):
                 event_data['modified']['rows'] += rows
             if type_ == "column":
                 columns = list(range(c1, c2))
-                event_data['modified']['columns'] += columns
+                event_data['modified']['cols'] += columns
             
         if self.extra_end_ctrl_x_func is not None:
             self.extra_end_ctrl_x_func(
@@ -1747,9 +1747,9 @@ class MainTable(tk.Canvas):
             }
             modified_cols = list(range(undo_storage[1]["sheet_col_num"], len(self.col_positions)-1))
             moved_cols = [(end+len(to_del), end) for end in modified_cols]
-            event_data['deleted']['columns'] = list(to_del)
-            event_data['modified']['columns'] = modified_cols
-            event_data['moved']['columns'] = moved_cols
+            event_data['deleted']['cols'] = list(to_del)
+            event_data['modified']['cols'] = modified_cols
+            event_data['moved']['cols'] = moved_cols
             if len(self.col_positions) > 1:
                 start_col = (
                     undo_storage[1]["sheet_col_num"]
@@ -1817,9 +1817,9 @@ class MainTable(tk.Canvas):
             modified_cols = list(range(min(deleted_cols), len(self.col_positions)-1))
             added_cols = deleted_cols
             moved_cols = [(end-len(deleted_cols), end) for end in modified_cols if end not in deleted_cols]
-            event_data['added']['columns'] = added_cols
-            event_data['modified']['columns'] = modified_cols
-            event_data['moved']['columns'] = moved_cols
+            event_data['added']['cols'] = added_cols
+            event_data['modified']['cols'] = modified_cols
+            event_data['moved']['cols'] = moved_cols
         self.refresh()
         if self.extra_end_ctrl_z_func is not None:
             self.extra_end_ctrl_z_func(

--- a/tksheet/_tksheet_other_classes.py
+++ b/tksheet/_tksheet_other_classes.py
@@ -397,3 +397,39 @@ def get_seq_without_gaps_at_index(seq, position):
     if reverse_gap is not None:
         seq[:] = seq[reverse_gap:]
     return seq
+
+def sheet_modified_event_data(
+        name: str = None,
+        action: str = None,
+        modified_cells: list[tuple] = [],
+        modified_rows: list = [],
+        modified_cols: list = [],
+        deleted_rows: list = [],
+        deleted_cols: list = [],
+        added_rows: list = [],
+        added_cols: list = [],
+        moved_rows: list[tuple] = [],
+        moved_cols: list[tuple] = []
+    ) -> dict:
+    return {
+        "name": name,
+        "action": action,
+        "modified": {
+            "cells": modified_cells,
+            "rows": modified_rows,
+            "cols": modified_cols,
+        },
+        "deleted": {
+            "rows": deleted_rows,
+            "cols": modified_cols,
+        },
+        "added": {
+            "rows": added_rows,
+            "cols": modified_cols,
+        },
+        "moved": {
+            "rows": moved_rows,
+            "cols": modified_cols,
+        },
+    }
+

--- a/tksheet/_tksheet_other_classes.py
+++ b/tksheet/_tksheet_other_classes.py
@@ -421,15 +421,15 @@ def sheet_modified_event_data(
         },
         "deleted": {
             "rows": deleted_rows,
-            "cols": modified_cols,
+            "cols": deleted_cols,
         },
         "added": {
             "rows": added_rows,
-            "cols": modified_cols,
+            "cols": added_cols,
         },
         "moved": {
             "rows": moved_rows,
-            "cols": modified_cols,
+            "cols": moved_cols,
         },
     }
 

--- a/tksheet/_tksheet_row_index.py
+++ b/tksheet/_tksheet_row_index.py
@@ -929,11 +929,10 @@ class RowIndex(tk.Canvas):
                                 int(r),
                             )
                         )
-                    event_data = {'action': 'move_rows', 
-                                  'modified': {'cells': [], 'rows': [], 'cols': []}, 
-                                  'deleted': {'rows': [], 'cols': []}, 
-                                  'added': {'rows': [], 'cols': []}}
-                    event_data["modified"]["rows"] = list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1))
+                    event_data = sheet_modified_event_data(
+                        action="move_rows",
+                        modified_rows=list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1)),
+                    )
                     self.parentframe.emit_event("<<SheetModified>>", event_data)
         elif (
             self.b1_pressed_loc is not None
@@ -2231,11 +2230,10 @@ class RowIndex(tk.Canvas):
             self.set_row_height_run_binding(r, only_set_if_too_small=False)
         if redraw:
             self.MT.refresh()
-        event_data = {'action': 'edit_index', 
-                      'modified': {'cells': [], 'rows': [], 'cols': []}, 
-                      'deleted': {'rows': [], 'cols': []}, 
-                      'added': {'rows': [], 'cols': []}}
-        event_data['modified']['rows'].append(datarn)
+        event_data = sheet_modified_event_data(
+            action="edit_index",
+            row=[datarn],
+        )
         self.parentframe.emit_event("<<SheetModified>>", event_data)
 
     def set_cell_data(self, datarn=None, value=""):

--- a/tksheet/_tksheet_row_index.py
+++ b/tksheet/_tksheet_row_index.py
@@ -929,9 +929,16 @@ class RowIndex(tk.Canvas):
                                 int(r),
                             )
                         )
+                    moved_rows = [(start, end) for start, end in zip(orig_selected, new_selected) if start != end]
+                    modified_rows = list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1))
+                    direction = -1 if r < rm1start else 1
+                    displacement = -direction * totalrows
+                    displaced_rows = [(start, start+displacement) for start in modified_rows if start not in orig_selected]
+                    moved_rows += displaced_rows
                     event_data = sheet_modified_event_data(
                         action="move_rows",
-                        modified_rows=list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1)),
+                        modified_rows=modified_rows,
+                        moved_rows=moved_rows,
                     )
                     self.parentframe.emit_event("<<SheetModified>>", event_data)
         elif (

--- a/tksheet/_tksheet_row_index.py
+++ b/tksheet/_tksheet_row_index.py
@@ -929,7 +929,12 @@ class RowIndex(tk.Canvas):
                                 int(r),
                             )
                         )
-                    self.parentframe.emit_event("<<SheetModified>>")
+                    event_data = {'action': 'move_rows', 
+                                  'modified': {'cells': [], 'rows': [], 'cols': []}, 
+                                  'deleted': {'rows': [], 'cols': []}, 
+                                  'added': {'rows': [], 'cols': []}}
+                    event_data["modified"]["rows"] = list(range(min(list(orig_selected)+list(new_selected)), max(list(orig_selected)+list(new_selected))+1))
+                    self.parentframe.emit_event("<<SheetModified>>", event_data)
         elif (
             self.b1_pressed_loc is not None
             and self.rsz_w is None
@@ -2226,7 +2231,12 @@ class RowIndex(tk.Canvas):
             self.set_row_height_run_binding(r, only_set_if_too_small=False)
         if redraw:
             self.MT.refresh()
-        self.parentframe.emit_event("<<SheetModified>>")
+        event_data = {'action': 'edit_index', 
+                      'modified': {'cells': [], 'rows': [], 'cols': []}, 
+                      'deleted': {'rows': [], 'cols': []}, 
+                      'added': {'rows': [], 'cols': []}}
+        event_data['modified']['rows'].append(datarn)
+        self.parentframe.emit_event("<<SheetModified>>", event_data)
 
     def set_cell_data(self, datarn=None, value=""):
         if isinstance(self.MT._row_index, int):


### PR DESCRIPTION
I have added some data that gets packaged with each event, it is still somewhat incomplete, but provides a major upgrade in terms of how external code can interact with tksheet. Each event now broadcasts the name of the widget that broadcasts it (which can now be set as an optional property of `Sheet`), this is so users can identify and retrieve what sheet broadcast the event in cases where they are working with multiple active sheets. `<<SheetModified>>` events also contain an `action` field that details what user action triggered the event, and three other fields (`modified`, `added` and `deleted`, which contain some information about how the data has been changed, more on this later. `<<SheetRedrawn>>` events now contain information about whether the table, headers, or indexes have been redrawn for minor performance improvements in rare cases where the user is attaching significant numbers of elements to their sheet. 


### A Brief Explanation of tkinter Widget Names. 
In tkinter, each widget stores a kind of relative path to its children that can be used to retrieve the objects. Its a really useful feature when you have a lot of widgets going on and events to organise. Each widget has a name, which can be anything you like. In the demo attached, we have a sheet (named `"foo"`) sitting in a frame (name is `"!frame"` by default). We can retrieve this widget by calling `app.nametowidget("!frame.foo")`. This allows users to define unique names for each sheet widget so that event listeners only have to act on the sheet that was actually modified.

### How the modified data parameters work

The way I have currently implemented the data that come package with `<<SheetModified>>` events are quite simple and perhaps might be expanded, but I'll briefly justify my implementation and how I intend it to be used. In my mind, `<<SheetModified>>` listeners are typically going to be processes outside of the sheet that a developer wants to be automatically run every time the user alters a sheet. At least, this is what I have been using them for. The issue is that external code is kind of blind to what is actually happening between changes, and I found myself writing a lot of code just to check for changes that the sheet already knew it was making. This is pretty redundant and can impact performance when you have to check a massive sheet for one changed cell every time a user makes a change. As they are currently implemented, the data that is packaged inside the `<<SheetModified>>` data is designed to tell external code what cells/rows/columns were actually changed. I'll list the fields and subfields, with the rules for each:

`"modified":`
This tells external code what areas of the sheet have been affected by a change. These MUST only refer to VALID sheet data after the change. i.e. if a column at the end of a sheet is deleted, then it must not appear here because if external code tried to retrieve data from it, it will get an error. If a row is removed from the middle of the table, then each proceeding row will count as modified.
 - `"cells"` (`list[tuple]`) A list of changed table cells.
 - `"cols"` (`list[int]`) A list of changed columns, only appears when a header or the whole column is changed (typically when columns are appended or moved around the table). This basically tells the code it check every value in this column for changes/
 - `"rows"` (`list[int]`) See `"cols"` above.

`"deleted":` and `"added":`
This only has rows and columns, as it is impossible to remove individual cells from the table. These are intended to inform external code about changes to the shape of the table. Note that this is only for right-click delete row/column events. Delete-key events are just considered modifications because the don't alter the underlying shape of the data. 
 - `"cols"`, `"rows"`

`"moved"` (Not yet implemented, will get to this tomorrow):
Haven't implemented this yet but it will probably take the following format:
 - `"cols"`, `"rows"` (`list[tuple]`) a list of tuples in the form ("from index", "to index"). 

Below is a small demo to see how this all works. Let me know if you think I'm barking up the right tree here. 
Cheers!
C.

### Demo

```
from tksheet import Sheet
import tkinter as tk

class demo(tk.Tk):
    def __init__(self):
        tk.Tk.__init__(self)
        self.frame = tk.Frame(self)
        self.sheet = Sheet(self.frame, name = 'foo')
        self.sheet.enable_bindings()
        self.frame.pack(expand=True, fill='both')
        self.sheet.pack(expand=True, fill='both')
        self.sheet.set_sheet_data([[None, None, None],['e',1, None]])
        # self.sheet.CH.auto_set_header_height() # New function
        self.sheet.RI
        # self.bind("<<SheetModified>>", self.print_stuff)
        Sheet.bind_event(self, "<<SheetModified>>", self.print_stuff)
        print(self.nametowidget(".!frame.foo").__repr__()) # How names work in tkinter

    def print_stuff(self, e):
        print(e.data)
        
app = demo()
app.mainloop()


```