### PR TITLE
conda-forge channel support

### DIFF
--- a/.github/workflows/publish-conda.yml
+++ b/.github/workflows/publish-conda.yml
@@ -1,0 +1,15 @@
+name: publish_conda
+
+on:
+  release:
+    types: [published]
+    
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3.1.0
+    - name: publish-to-conda
+      uses: fcakyon/conda-publish-action@v1.3
+      with:
+        AnacondaToken: ${{ secrets.ANACONDA_TOKEN }}

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "tksheet" %}
+{% set version = "6.2.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/ragardner/tksheet/archive/{{ version }}.tar.gz
+  sha256: c370e2a1f2c63f364271d44fd811ab2dfbdba204ba6f9cb3bdb1a82b99cc0c65
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - tksheet
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/ragardner/tksheet
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - ragardner


### PR DESCRIPTION
Hello,

I'm developing a package that tksheet is a dependency of. I want to put it on conda-forge, but that means all my package's dependencies must also be on conda-forge. This PR has the meta.yaml file needed and adds a GH action to publish to conda (see this link for configuring it with a secret: https://github.com/marketplace/actions/publish-conda-forge).

-Will Golay